### PR TITLE
Renamed field senderAccountNumber

### DIFF
--- a/src/Banklink/Response/PaymentResponse.php
+++ b/src/Banklink/Response/PaymentResponse.php
@@ -14,7 +14,7 @@ class PaymentResponse extends Response
     protected $orderId;
     protected $currency;
     protected $senderName;
-    protected $senderAccountNumber;
+    protected $senderBankAccount;
 
     /**
      * Set orderId


### PR DESCRIPTION
Fixed mistake in the field name. It was declared as $senderAccountNumber, but used in methods as $this->senderBankAccount.